### PR TITLE
Increase default max memory for the GWT compiler

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/eclipse/EclipseMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/eclipse/EclipseMojo.java
@@ -66,12 +66,12 @@ public class EclipseMojo
 
     /**
      * Extra JVM arguments that are passed to the GWT-Maven generated scripts (for compiler, shell, etc - typically use
-     * -Xmx512m here, or -XstartOnFirstThread, etc).
+     * -Xmx2G here, or -XstartOnFirstThread, etc).
      * <p>
      * Can be set from command line using '-Dgwt.extraJvmArgs=...', defaults to setting max Heap size to be large enough
      * for most GWT use cases.
      */
-    @Parameter(property = "gwt.extraJvmArgs", defaultValue = "-Xmx512m")
+    @Parameter(property = "gwt.extraJvmArgs", defaultValue = "-Xmx1G")
     private String extraJvmArgs;
 
     /**


### PR DESCRIPTION
Some products like Spreadsheet requires -Xmx1G to be able to compile the widget set properly with Vaadin Framework 8, possibly related including all the compatibility classes.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/maven-plugin/72)
<!-- Reviewable:end -->
