### PR TITLE
Replace classpath argument with environment variable

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/shell/JavaCommand.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/JavaCommand.java
@@ -274,13 +274,15 @@ public class JavaCommand
         {
             command.addAll( this.jvmArgs );
         }
-        command.add( "-classpath" );
+
         List<String> path = new ArrayList<String>( classpath.size() );
         for ( File file : classpath )
         {
             path.add( file.getAbsolutePath() );
         }
-        command.add( StringUtils.join( path.iterator(), File.pathSeparator ) );
+        environment("CLASSPATH", StringUtils.join( path.iterator(), File.pathSeparator ));
+
+
         if ( systemProperties != null )
         {
             for ( Map.Entry<?, ?> entry : systemProperties.entrySet() )
@@ -311,6 +313,7 @@ public class JavaCommand
                     cmd.addEnvironment( (String) entry.getKey(), (String) entry.getValue() );
                 }
             }
+
             log.debug( "Execute command :\n" + cmd.toString() );
             int status;
             if ( timeOut > 0 )


### PR DESCRIPTION
If the project has a lot of dependencies compiling widgetset
on Windows fails due to too long command line; to reduce
command line lenght classpath is given as
CLASSPATH environment variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/maven-plugin/73)
<!-- Reviewable:end -->
