### PR TITLE
chore: Downgrade xml-apis version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,7 +321,7 @@
     <dependency>
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis</artifactId>
-      <version>2.0.2</version>
+      <version>1.4.01</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
It seems that the newer 2.0.2 that *was* being included is *too new*. This causes a compilation failure on vaadin framework 7.7 on CI cluster.