### PR TITLE
chore: Update plexus-archiver version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -311,7 +311,7 @@
       <!-- used to unpack gwt native libs -->
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>2.6.3</version>
+      <version>4.8.0</version>
     </dependency>
 	<dependency>
       <!--  used for GwtSourcesJarMojo -->
@@ -322,7 +322,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.13.1</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Update vulnerable version of plexus-archiver and junit as a security chore.