### PR TITLE
fix: get framework version from runtime vaadin-server variant

### DIFF
--- a/src/main/java/org/codehaus/mojo/gwt/shell/CompileMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/CompileMojo.java
@@ -430,8 +430,12 @@ public class CompileMojo
             if ("vaadin-server".equals(artifact.getArtifactId()) ||
                     "vaadin-server-mpr-jakarta".equals(artifact.getArtifactId())) {
                 vaadinVersion = artifact.getVersion();
-                break;
             }
+        }
+        if (vaadinVersion == null) {
+            throw new IllegalStateException("Unable to determine Vaadin version: " +
+                    "'com.vaadin:vaadin-server' or 'com.vaadin:vaadin-server-mpr-jakarta' " +
+                    "not found in project dependencies.");
         }
 
         // Always check for Vaadin license

--- a/src/main/java/org/codehaus/mojo/gwt/shell/CompileMojo.java
+++ b/src/main/java/org/codehaus/mojo/gwt/shell/CompileMojo.java
@@ -427,8 +427,10 @@ public class CompileMojo
         Set<Artifact> artifacts = getProject().getArtifacts();
         for (Artifact artifact : artifacts) {
             // Store the vaadin version
-            if ("vaadin-server".equals(artifact.getArtifactId())) {
+            if ("vaadin-server".equals(artifact.getArtifactId()) ||
+                    "vaadin-server-mpr-jakarta".equals(artifact.getArtifactId())) {
                 vaadinVersion = artifact.getVersion();
+                break;
             }
         }
 


### PR DESCRIPTION
In MPR projects with Vaadin 24 vaadin-server is replaced by vaadin-server-mpr-jakarta. This change gets framework version from the artifact present at runtime.