### PR TITLE
chore: Update jdom dependency for security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -348,8 +348,8 @@
     </dependency>    
     <dependency>
       <groupId>org.jdom</groupId>
-      <artifactId>jdom</artifactId>
-      <version>1.1.3</version>
+      <artifactId>jdom2</artifactId>
+      <version>2.0.6.1</version>
     </dependency>
     <dependency>
       <groupId>jaxen</groupId>


### PR DESCRIPTION
org.jdom.jdom is flagged as vulnerable to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-33813

See also https://mvnrepository.com/artifact/org.jdom/jdom/1.1.3

Update to 2.0.6.1 which is the latest available version at time of commit.

WIP: requires testing to make sure this doesn't cause code incompatibilities