### PR TITLE
chore: Update JDOM dependency for security (V7)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -372,8 +372,8 @@
     </dependency>    
     <dependency>
       <groupId>org.jdom</groupId>
-      <artifactId>jdom</artifactId>
-      <version>1.1.3</version>
+      <artifactId>jdom2</artifactId>
+      <version>2.0.6.1</version>
     </dependency>
     <dependency>
       <groupId>jaxen</groupId>


### PR DESCRIPTION
Update JDOM to 2.0.6.1 to fix CVE