### PR TITLE
chore: Make unit tests work again (V8)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         </contributor>
     </contributors>
     <prerequisites>
-        <maven>3</maven>
+        <maven>3.5.0</maven>
     </prerequisites>
     <scm>
         <connection>scm:git:https://github.com/vaadin/maven-plugin.git</connection>
@@ -118,15 +118,14 @@
         <!-- This property is used in a filtered resources to check the version compatibility -->
         <vaadin.version>${project.version}</vaadin.version>
         <vaadin.version.latest>8.30.0</vaadin.version.latest> <!-- Set by CI environment -->
-        <gwt.version>2.11.0</gwt.version>
-        <sisu.version>0.3.5</sisu.version>
+        <gwt.version>2.11.0</gwt.version>  <!-- GWT-SERVLET is hardcoded to 2.10.0 -->
+        <gwt.servlet.version>2.10.0</gwt.servlet.version>
         <maven.version>3.9.9</maven.version>
         <resteasy.version>6.2.11.Final</resteasy.version>
 
         <!--  apt filtering doesn't support dot -->
         <vaadinVersion>${vaadin.version}</vaadinVersion>
         <gwtVersion>${gwt.version}</gwtVersion>
-        <sisuVersion>${sisu.version}</sisuVersion>
         <mavenVersion>${maven.version}</mavenVersion>
 
         <!-- for older tools -->
@@ -287,12 +286,21 @@
             <artifactId>doxia-site-renderer</artifactId>
             <version>${doxia-sitetoolsVersion}</version>
         </dependency>
+        
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-container-default</artifactId>
+            <version>2.1.1</version>
+            <scope>test</scope>
+        </dependency>
+        
         <dependency>
             <groupId>org.apache.maven.plugin-testing</groupId>
             <artifactId>maven-plugin-testing-harness</artifactId>
-            <version>2.1</version>
+            <version>3.5.0</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
@@ -366,11 +374,6 @@
             <version>4.0.2</version>
         </dependency>
 
-        <dependency>
-            <groupId>org.eclipse.sisu</groupId>
-            <artifactId>org.eclipse.sisu.plexus</artifactId>
-            <version>${sisu.version}</version>
-        </dependency>
         <dependency>
             <!-- used to generate eclipse .launch files -->
             <groupId>org.freemarker</groupId>
@@ -769,12 +772,12 @@
                             <settingsFile>src/it/settings.xml</settingsFile>
                             <cloneProjectsTo>${project.build.directory}/it-tests</cloneProjectsTo>
                             <extraArtifacts>
-                                <extraArtifact>com.google.gwt:gwt-servlet:${gwtVersion}:jar</extraArtifact>
+                                <extraArtifact>com.google.gwt:gwt-servlet:${gwt.servlet.version}:jar</extraArtifact>
                                 <!-- for some reason, com.google.web.bindery:requestfactory isn't
                                 installed,
                                      whereas it's needed by com.google.gwt:gwt -->
                                 <extraArtifact>
-                                    com.google.web.bindery:requestfactory:${gwtVersion}:pom</extraArtifact>
+                                    com.google.web.bindery:requestfactory:${gwt.servlet.version}:pom</extraArtifact>
                             </extraArtifacts>
                         </configuration>
                         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,6 @@
         <vaadin.version>${project.version}</vaadin.version>
         <vaadin.version.latest>8.30.0</vaadin.version.latest> <!-- Set by CI environment -->
         <gwt.version>2.11.0</gwt.version>  <!-- GWT-SERVLET is hardcoded to 2.10.0 -->
-        <gwt.servlet.version>2.10.0</gwt.servlet.version>
         <maven.version>3.9.9</maven.version>
         <resteasy.version>6.2.11.Final</resteasy.version>
 
@@ -772,12 +771,9 @@
                             <settingsFile>src/it/settings.xml</settingsFile>
                             <cloneProjectsTo>${project.build.directory}/it-tests</cloneProjectsTo>
                             <extraArtifacts>
-                                <extraArtifact>com.google.gwt:gwt-servlet:${gwt.servlet.version}:jar</extraArtifact>
-                                <!-- for some reason, com.google.web.bindery:requestfactory isn't
-                                installed,
-                                     whereas it's needed by com.google.gwt:gwt -->
+                                <extraArtifact>org.gwtproject:gwt-servlet:${gwt.version}:jar</extraArtifact>
                                 <extraArtifact>
-                                    com.google.web.bindery:requestfactory:${gwt.servlet.version}:pom</extraArtifact>
+                                    org.gwtproject.web.bindery:requestfactory-server:${gwt.version}:pom</extraArtifact>
                             </extraArtifacts>
                         </configuration>
                         <executions>

--- a/src/it/MGWT-226/pom.xml
+++ b/src/it/MGWT-226/pom.xml
@@ -38,7 +38,7 @@
       <dependency>
         <groupId>com.google.gwt</groupId>
         <artifactId>gwt-servlet</artifactId>
-        <version>@gwt.version@</version>
+        <version>@gwt.servlet.version@</version>
       </dependency>
       <dependency>
         <groupId>com.google.gwt</groupId>

--- a/src/it/MGWT-226/pom.xml
+++ b/src/it/MGWT-226/pom.xml
@@ -36,12 +36,12 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt-servlet</artifactId>
-        <version>@gwt.servlet.version@</version>
+        <version>@gwt.version@</version>
       </dependency>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt-user</artifactId>
         <version>@gwt.version@</version>
       </dependency>

--- a/src/it/MGWT-290/pom.xml
+++ b/src/it/MGWT-290/pom.xml
@@ -55,13 +55,13 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.1</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>gwt-maven-plugin</artifactId>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <configuration>
           <genParam>false</genParam>
@@ -96,7 +96,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/it/MGWT-315-generateasync-with-compiled-classes/pom.xml
+++ b/src/it/MGWT-315-generateasync-with-compiled-classes/pom.xml
@@ -27,8 +27,8 @@
   	<finalName>hello</finalName>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>gwt-maven-plugin</artifactId>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <configuration>
           <draftCompile>true</draftCompile>
@@ -49,8 +49,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 
@@ -59,7 +59,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
       <scope>provided</scope>

--- a/src/it/MGWT-352/pom.xml
+++ b/src/it/MGWT-352/pom.xml
@@ -27,8 +27,8 @@
   	<finalName>hello</finalName>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>gwt-maven-plugin</artifactId>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <configuration>
           <draftCompile>true</draftCompile>
@@ -55,8 +55,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 
@@ -65,7 +65,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
       <scope>provided</scope>

--- a/src/it/MGWT-372/pom.xml
+++ b/src/it/MGWT-372/pom.xml
@@ -26,8 +26,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>gwt-maven-plugin</artifactId>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <configuration>
           <draftCompile>true</draftCompile>
@@ -46,8 +46,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 
@@ -56,7 +56,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
       <scope>provided</scope>

--- a/src/it/async-with-inner-class/pom.xml
+++ b/src/it/async-with-inner-class/pom.xml
@@ -27,12 +27,12 @@
   	<finalName>hello</finalName>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>gwt-maven-plugin</artifactId>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <configuration>
           <draftCompile>true</draftCompile>
-          <optimizationLevel>0</optimizationLevel>     
+          <optimizationLevel>0</optimizationLevel>
           <soyc>false</soyc>   
         </configuration>
         <executions>
@@ -55,8 +55,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 
@@ -65,7 +65,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>com.vaadin</groupId>
+      <artifactId>vaadin-server</artifactId>
+      <version>@vaadin.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
       <scope>provided</scope>

--- a/src/it/compile-gwt-sdk-first/pom.xml
+++ b/src/it/compile-gwt-sdk-first/pom.xml
@@ -31,13 +31,13 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.1</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>gwt-maven-plugin</artifactId>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <configuration>
           <inplace>true</inplace>
@@ -64,7 +64,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/it/compile-report/pom.xml
+++ b/src/it/compile-report/pom.xml
@@ -31,8 +31,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.1</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
@@ -41,8 +41,8 @@
         <version>3.4</version>
       </plugin>       
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>gwt-maven-plugin</artifactId>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <configuration>
           <logLevel>INFO</logLevel>
@@ -95,7 +95,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/it/compile/pom.xml
+++ b/src/it/compile/pom.xml
@@ -31,13 +31,13 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.1</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>gwt-maven-plugin</artifactId>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <configuration>
           <genParam>false</genParam>
@@ -53,23 +53,23 @@
           <deploy>${project.build.directory}/deploy</deploy>
           <persistentunitcache>true</persistentunitcache>
           <persistentunitcachedir>${project.build.directory}/persistentunitcache</persistentunitcachedir>
-          <enableClosureCompiler>true</enableClosureCompiler>
-          <disableAggressiveOptimization>true</disableAggressiveOptimization>
+          <!--<enableClosureCompiler>true</enableClosureCompiler>-->
+          <!--<disableAggressiveOptimization>true</disableAggressiveOptimization>-->
           <compilerMetrics>true</compilerMetrics>
           <fragmentCount>2</fragmentCount>
           <clusterFunctions>false</clusterFunctions>
-          <enforceStrictResources>true</enforceStrictResources>
+          <!--<enforceStrictResources>true</enforceStrictResources>-->
           <inlineLiteralParameters>false</inlineLiteralParameters>
           <optimizeDataflow>false</optimizeDataflow>
           <ordinalizeEnums>false</ordinalizeEnums>
           <removeDuplicateFunctions>false</removeDuplicateFunctions>
           <saveSource>true</saveSource>
           <saveSourceOutput>${project.build.directory}/savedSources</saveSourceOutput>
-          <incrementalCompileWarnings>true</incrementalCompileWarnings>
-          <missingDepsFile>${project.build.directory}/missingDeps</missingDepsFile>
-          <jsInteropMode>JS</jsInteropMode>
+          <!--<incrementalCompileWarnings>true</incrementalCompileWarnings>-->
+          <!--<missingDepsFile>${project.build.directory}/missingDeps</missingDepsFile>-->
+          <!--<jsInteropMode>JS</jsInteropMode>-->
           <namespace>NONE</namespace>
-          <overlappingSourceWarnings>true</overlappingSourceWarnings>
+          <!--<overlappingSourceWarnings>true</overlappingSourceWarnings>-->
           <methodNameDisplayMode>FULL</methodNameDisplayMode>
         </configuration>
         <executions>
@@ -86,7 +86,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>com.vaadin</groupId>
+      <artifactId>vaadin-server</artifactId>
+      <version>@vaadin.version@</version>
+    </dependency>
+    <dependency>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/it/css-mojo/pom.xml
+++ b/src/it/css-mojo/pom.xml
@@ -27,8 +27,8 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>gwt-maven-plugin</artifactId>
+          <groupId>com.vaadin</groupId>
+          <artifactId>vaadin-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>
       </plugins>
@@ -57,7 +57,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/it/gwt-test-fail/pom.xml
+++ b/src/it/gwt-test-fail/pom.xml
@@ -21,13 +21,13 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.1</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>    
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>gwt-maven-plugin</artifactId>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <configuration>
           <logLevel>INFO</logLevel>
@@ -60,15 +60,15 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-servlet</artifactId>
-      <version>@gwt.servlet.version@</version>
+      <version>@gwt.version@</version>
       <scope>compile</scope>
     </dependency>
     <!-- tests -->

--- a/src/it/gwt-test-fail/pom.xml
+++ b/src/it/gwt-test-fail/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>com.google.gwt</groupId>
       <artifactId>gwt-servlet</artifactId>
-      <version>@gwt.version@</version>
+      <version>@gwt.servlet.version@</version>
       <scope>compile</scope>
     </dependency>
     <!-- tests -->

--- a/src/it/i18n-creator/pom.xml
+++ b/src/it/i18n-creator/pom.xml
@@ -27,8 +27,8 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>gwt-maven-plugin</artifactId>
+          <groupId>com.vaadin</groupId>
+          <artifactId>vaadin-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>
       </plugins>
@@ -60,7 +60,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/it/indirect-remote-service/pom.xml
+++ b/src/it/indirect-remote-service/pom.xml
@@ -27,8 +27,8 @@
     <finalName>hello</finalName>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>gwt-maven-plugin</artifactId>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <configuration>
           <draftCompile>true</draftCompile>
@@ -45,8 +45,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 
@@ -55,7 +55,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
       <scope>provided</scope>

--- a/src/it/inherited-modules/pom.xml
+++ b/src/it/inherited-modules/pom.xml
@@ -28,13 +28,13 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
        <plugin>
-    <groupId>org.codehaus.mojo</groupId>
-    <artifactId>gwt-maven-plugin</artifactId>
+    <groupId>com.vaadin</groupId>
+    <artifactId>vaadin-maven-plugin</artifactId>
     <version>@pom.version@</version>
     <configuration>
       <inplace>true</inplace>
@@ -80,7 +80,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/it/mergewebxmlmojo/pom.xml
+++ b/src/it/mergewebxmlmojo/pom.xml
@@ -31,13 +31,13 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.1</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>gwt-maven-plugin</artifactId>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <configuration>
           <inplace>true</inplace>
@@ -79,7 +79,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/it/mergewebxmlmojoannotation/pom.xml
+++ b/src/it/mergewebxmlmojoannotation/pom.xml
@@ -31,13 +31,13 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>gwt-maven-plugin</artifactId>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <configuration>
           <inplace>true</inplace>
@@ -75,7 +75,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/it/mergewebxmlmojopathasis/pom.xml
+++ b/src/it/mergewebxmlmojopathasis/pom.xml
@@ -31,13 +31,13 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.1</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>gwt-maven-plugin</artifactId>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <configuration>
           <inplace>true</inplace>
@@ -80,7 +80,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/it/mgwt-186/pom.xml
+++ b/src/it/mgwt-186/pom.xml
@@ -27,8 +27,8 @@
   	<finalName>hello</finalName>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>gwt-maven-plugin</artifactId>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <configuration>
           <draftCompile>true</draftCompile>
@@ -46,8 +46,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
 
@@ -56,7 +56,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
       <scope>provided</scope>

--- a/src/it/reactor/pom.xml
+++ b/src/it/reactor/pom.xml
@@ -31,8 +31,8 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>gwt-maven-plugin</artifactId>
+          <groupId>com.vaadin</groupId>
+          <artifactId>vaadin-maven-plugin</artifactId>
           <version>@pom.version@</version>
         </plugin>
         <plugin>
@@ -46,8 +46,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.1</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
     </plugins>
@@ -56,15 +56,15 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt-user</artifactId>
         <version>@gwt.version@</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt-servlet</artifactId>
-        <version>@gwt.servlet.version@</version>
+        <version>@gwt.version@</version>
         <scope>runtime</scope>
       </dependency>
     </dependencies>

--- a/src/it/reactor/pom.xml
+++ b/src/it/reactor/pom.xml
@@ -64,7 +64,7 @@
       <dependency>
         <groupId>com.google.gwt</groupId>
         <artifactId>gwt-servlet</artifactId>
-        <version>@gwt.version@</version>
+        <version>@gwt.servlet.version@</version>
         <scope>runtime</scope>
       </dependency>
     </dependencies>

--- a/src/it/resources-mojo/pom.xml
+++ b/src/it/resources-mojo/pom.xml
@@ -30,13 +30,13 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.1</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>gwt-maven-plugin</artifactId>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-maven-plugin</artifactId>
         <version>@pom.version@</version>
         <configuration>
           <inplace>true</inplace>
@@ -64,7 +64,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <version>@gwt.version@</version>
     </dependency>

--- a/src/main/archetype/archetype-resources/pom.xml
+++ b/src/main/archetype/archetype-resources/pom.xml
@@ -16,8 +16,8 @@
     <gwtVersion>${gwtVersion}</gwtVersion>
 
     <!-- GWT needs at least java 1.6 -->
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -25,7 +25,7 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>com.google.gwt</groupId>
+        <groupId>org.gwtproject</groupId>
         <artifactId>gwt</artifactId>
         <version>\${gwtVersion}</version>
         <type>pom</type>
@@ -36,17 +36,17 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-servlet</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-user</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.gwt</groupId>
+      <groupId>org.gwtproject</groupId>
       <artifactId>gwt-dev</artifactId>
       <scope>provided</scope>
     </dependency>
@@ -66,8 +66,8 @@
 
       <!-- GWT Maven Plugin -->
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>gwt-maven-plugin</artifactId>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-maven-plugin</artifactId>
         <version>${project.version}</version>
         <executions>
           <execution>
@@ -78,6 +78,7 @@
             </goals>
           </execution>
         </executions>
+
         <!-- Plugin configuration. There are many available options, see 
           gwt-maven-plugin documentation at codehaus.org -->
         <configuration>


### PR DESCRIPTION
The unit tests have been broken for an extended time due to dependency clash, but it seems that project structure also needs to change since the update to GWT-2.11.0